### PR TITLE
Add clock drawer option (fixes #14)

### DIFF
--- a/src/Data/OrgMode/Parse/Attoparsec/Document.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Document.hs
@@ -25,8 +25,8 @@ import           Data.OrgMode.Parse.Attoparsec.Section  (nonHeadline)
 import           Data.OrgMode.Parse.Types
 
 ------------------------------------------------------------------------------
-parseDocument :: [Text] -> Attoparsec.Parser Text Document
-parseDocument otherKeywords =
+parseDocument :: [Text] -> Maybe Text -> Attoparsec.Parser Text Document
+parseDocument otherKeywords mClockDrawer =
   Document
     <$> (Text.unlines <$> many' nonHeadline)
-    <*> many' (headlineBelowDepth otherKeywords 0)
+    <*> many' (headlineBelowDepth otherKeywords mClockDrawer 0)

--- a/src/Data/OrgMode/Parse/Attoparsec/Headline.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headline.hs
@@ -19,6 +19,7 @@ module Data.OrgMode.Parse.Attoparsec.Headline
 , headingPriority
 , parseStats
 , parseTags
+, parseTitle
 , mkTitleMeta
 , TitleMeta
 )
@@ -65,9 +66,10 @@ newtype TitleMeta = TitleMeta (Text, Maybe Stats, Maybe [Tag])
 --
 -- Use a @Depth@ of 0 to parse any headline.
 headlineBelowDepth :: [Text]
+                  -> Maybe Text
                   -> Depth
                   -> Attoparsec.Parser Text Headline
-headlineBelowDepth stateKeywords d = do
+headlineBelowDepth stateKeywords mClockDrawer d = do
   depth'    <- headlineDepth d <* skipOnlySpace
   stateKey  <- option Nothing (Just <$> parseStateKeyword stateKeywords <* skipOnlySpace)
   priority' <- option Nothing (Just <$> headingPriority <* skipOnlySpace)
@@ -79,8 +81,8 @@ headlineBelowDepth stateKeywords d = do
     , (fromMaybe [] -> tags')
     ) <- parseTitle
 
-  section'      <- parseSection
-  subHeadlines' <- option [] $ many' (headlineBelowDepth stateKeywords (d + 1))
+  section'      <- parseSection mClockDrawer
+  subHeadlines' <- option [] $ many' (headlineBelowDepth stateKeywords mClockDrawer (d + 1))
 
   skipSpace
   pure $ Headline

--- a/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
@@ -14,6 +14,7 @@
 module Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 ( parseDrawer
 , property
+, parseDelim
 , PropertyKey
 , PropertyVal
 )

--- a/test/Document.hs
+++ b/test/Document.hs
@@ -25,11 +25,11 @@ parserSmallDocumentTests = testGroup "Attoparsec Small Document"
       testDocS "* T" (Document "" [emptyHeadline {title="T"}])
   , testCase "Parse Document from File" $ testDocFile
   ]
-  where testDocS s r = expectParse (parseDocument kw) s (Right r)
-        testDocF s   = expectParse (parseDocument kw) s (Left "Some failure")
+  where testDocS s r = expectParse (parseDocument kw Nothing) s (Right r)
+        testDocF s   = expectParse (parseDocument kw Nothing) s (Left "Some failure")
         testDocFile  = do
           doc <- TextIO.readFile "test/test-document.org"
-          assertBool "Expected to parse document" . parseSucceeded $ parseOnly (parseDocument kw) doc
+          assertBool "Expected to parse document" . parseSucceeded $ parseOnly (parseDocument kw Nothing) doc
         kw           = ["TODO", "CANCELED", "DONE"]
         pText        = "Paragraph text\n.No headline here.\n##--------\n"
         parseSucceeded (Right _) = True

--- a/test/Headline.hs
+++ b/test/Headline.hs
@@ -22,4 +22,4 @@ parserHeadlineTests = testGroup "Attoparsec Headline"
     , (testCase "Parse Headline All But Title"       $ testHeadline "* DONE [#A] :WITH:KEYWORDS:\n")
     ]
   where
-    testHeadline = testParser (headlineBelowDepth ["TODO","CANCELED","DONE"] 0)
+    testHeadline = testParser (headlineBelowDepth ["TODO","CANCELED","DONE"] Nothing 0)

--- a/test/Section.hs
+++ b/test/Section.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+
+module Section (parserSectionTests) where
+
+import           Data.OrgMode.Parse
+import qualified Data.Text as T
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Util
+
+parserSectionTests :: TestTree
+parserSectionTests = testGroup "Attoparsec Section"
+    [ (testCase "Parse Section with clock drawer"
+       $ testClock (Just "LOGBOOK") clockDrawer)
+    , (testCase "Parse Section without clock drawer"
+       $ testClock Nothing clockNoDrawer)
+    ]
+  where
+    clockDrawer = T.intercalate "\n" [ ":LOGBOOK:"
+                                     , "CLOCK: [2017-02-08 Wed 13:40]--[2017-02-08 Wed 13:50] =>  0:10"
+                                     , ":END:"
+                                     ]
+    clockNoDrawer = "CLOCK: [2017-02-08 Wed 13:40]--[2017-02-08 Wed 13:50] =>  0:10"
+    testClock mDrawer txt = expectParse (parseSection mDrawer) txt (Right clockSection)
+
+clockSection = Section { sectionPlannings  = Plns mempty
+                       , sectionClocks     = [clockEntry]
+                       , sectionProperties = mempty
+                       , sectionParagraph  = ""
+                       }
+  where
+    clockEntry = (Just ts, Just (0,10))
+    dt x = DateTime { yearMonthDay = YMD' (YearMonthDay 2017 2 8)
+                    , dayName      = Just "Wed"
+                    , hourMinute   = Just (13,x)
+                    , repeater     = Nothing
+                    , delay        = Nothing
+                    }
+    ts = Timestamp { tsTime    = dt 40
+                   , tsActive  = Inactive
+                   , tsEndTime = Just (dt 50)
+                   }

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -6,6 +6,7 @@ module Main where
 import           Document
 import           Headline
 import           PropertyDrawer
+import           Section
 import           Test.Tasty
 import           Timestamps
 
@@ -20,4 +21,5 @@ tests = testGroup
           , parserTimestampTests
           , parserSmallDocumentTests
           , parserWeekdayTests
+          , parserSectionTests
           ]


### PR DESCRIPTION
It is common to have the clock entries inside a drawer, in fact, clock entries are stored in a "LOGBOOK" drawer by default. This patch adds a `Maybe Text` parameter to `parseDocument` that allows the user to specify a drawer name that clock entries are expected to be under.

This is a quick and dirty fix, as this does not allow for clock entries to be inside a drawer and outside a drawer within the same document. This also requires the user to specify the drawer to search for clock entries in. A more general solution might be to have the parser maintain some state while parsing so it can collect clock entries as they are encountered, no matter if they are in a drawer or not.

But either way, my clock entries are under a LOGBOOK drawer and I needed a quick fix. Here it is if you want.