### PR TITLE
Reorganizing the location of the types module and cleaning up some readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome!
 ![Hackage Version](https://img.shields.io/hackage/v/orgmode-parse.svg?style=flat)
-![Travis CI Status](https://travis-ci.org/digitalmentat/orgmode-parse.svg?branch=master)
+![Travis CI Status](https://travis-ci.org/ixmatus/orgmode-parse.svg?branch=master)
 
 `orgmode-parse` provides a top-level parser and collection of attoparsec parser
 combinators for org-mode structured text.
@@ -53,12 +53,15 @@ Parsing org-mode markup is currently being worked on.
 There are a few ways to build this library if you're developing a patch:
 
 - `stack build && stack test`, and
-- `nix-build -A orgmode-parse release.nix`
+- `nix-build --no-out-link --attr orgmode-parse release.nix`
 
-Generally, you should be using the ~stack build~ workflow but if you're on a
-NixOS system or have Nix installed and wish to test a Nix build (at the time of
-this writing, NixOS 16.09 has been used to build with) you can do so with the
-above ~nix-build~ invocation.
+You can also use the `nix-shell` provided cabal environment for incremental
+development:
+
+```shell
+$ nix-shell --attr orgmode-parse.env release.nix
+$ cabal build
+```
 
 # License
 [BSD3 Open Source Software License](https://github.com/digitalmentat/orgmode-parse/blob/master/LICENSE)

--- a/orgmode-parse.cabal
+++ b/orgmode-parse.cabal
@@ -41,7 +41,7 @@ Library
                   Data.OrgMode.Parse.Attoparsec.Section,
                   Data.OrgMode.Parse.Attoparsec.Time,
                   Data.OrgMode.Parse.Attoparsec.Util,
-                  Data.OrgMode.Parse.Types
+                  Data.OrgMode.Types
 
   Build-Depends:
                 base                      >= 4.8      && < 5
@@ -70,7 +70,7 @@ Test-Suite tests
                 Data.OrgMode.Parse.Attoparsec.Section,
                 Data.OrgMode.Parse.Attoparsec.Time,
                 Data.OrgMode.Parse.Attoparsec.Util,
-                Data.OrgMode.Parse.Types,
+                Data.OrgMode.Types,
                 Document,
                 Headline,
                 PropertyDrawer,

--- a/src/Data/OrgMode/Parse.hs
+++ b/src/Data/OrgMode/Parse.hs
@@ -13,9 +13,6 @@ module Data.OrgMode.Parse (
 -- * Parse OrgMode documents
   module Data.OrgMode.Parse.Attoparsec.Document
 
--- * OrgMode document types
-, module Data.OrgMode.Parse.Types
-
 -- * Parse headlines
 , module Data.OrgMode.Parse.Attoparsec.Headline
 
@@ -34,4 +31,3 @@ import           Data.OrgMode.Parse.Attoparsec.Headline
 import           Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 import           Data.OrgMode.Parse.Attoparsec.Section
 import           Data.OrgMode.Parse.Attoparsec.Time
-import           Data.OrgMode.Parse.Types

--- a/src/Data/OrgMode/Parse/Attoparsec/Document.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Document.hs
@@ -22,7 +22,7 @@ import qualified Data.Text                              as Text
 
 import           Data.OrgMode.Parse.Attoparsec.Headline
 import           Data.OrgMode.Parse.Attoparsec.Section  (nonHeadline)
-import           Data.OrgMode.Parse.Types
+import           Data.OrgMode.Types
 
 ------------------------------------------------------------------------------
 parseDocument :: [Text] -> Attoparsec.Parser Text Document

--- a/src/Data/OrgMode/Parse/Attoparsec/Headline.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Headline.hs
@@ -36,7 +36,7 @@ import           Text.Printf
 
 import           Data.OrgMode.Parse.Attoparsec.Section
 import           Data.OrgMode.Parse.Attoparsec.Util
-import           Data.OrgMode.Parse.Types
+import           Data.OrgMode.Types
 
 -- | Intermediate type for parsing titles in a headline after the
 -- state keyword and priority have been parsed.

--- a/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/PropertyDrawer.hs
@@ -19,15 +19,15 @@ module Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 )
 where
 
-import           Control.Applicative      ((*>), (<*))
-import           Data.Attoparsec.Text     as T
-import           Data.Attoparsec.Types    as Attoparsec
-import           Data.HashMap.Strict      (fromList)
-import           Data.Text                (Text)
-import qualified Data.Text                as Text
-import           Prelude                  hiding (concat, null, takeWhile)
+import           Control.Applicative   ((*>), (<*))
+import           Data.Attoparsec.Text  as T
+import           Data.Attoparsec.Types as Attoparsec
+import           Data.HashMap.Strict   (fromList)
+import           Data.Text             (Text)
+import qualified Data.Text             as Text
+import           Prelude               hiding (concat, null, takeWhile)
 
-import           Data.OrgMode.Parse.Types
+import           Data.OrgMode.Types
 
 type PropertyKey = Text
 type PropertyVal = Text

--- a/src/Data/OrgMode/Parse/Attoparsec/Section.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Section.hs
@@ -23,7 +23,7 @@ import           Prelude                                      hiding (unlines)
 
 import           Data.OrgMode.Parse.Attoparsec.PropertyDrawer
 import           Data.OrgMode.Parse.Attoparsec.Time
-import           Data.OrgMode.Parse.Types
+import           Data.OrgMode.Types
 
 -- | Parse a heading section
 --

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -51,12 +51,12 @@ import           Data.OrgMode.Types
 --
 -- > DEADLINE: <2015-05-10 17:00> CLOSED: <2015-04-1612:00>
 parsePlannings :: Attoparsec.Parser Text (HashMap PlanningKeyword Timestamp)
-parsePlannings = fromList <$> (many' (skipSpace *> planning <* skipSpace))
+parsePlannings = fromList <$> many' (skipSpace *> planning <* skipSpace)
   where
     planning =  (,) <$> pType <* char ':' <*> (skipSpace *> parseTimestamp)
-    pType    = choice [string "SCHEDULED" *> pure SCHEDULED
-                      ,string "DEADLINE"  *> pure DEADLINE
-                      ,string "CLOSED"    *> pure CLOSED
+    pType    = choice [ string "SCHEDULED" *> pure SCHEDULED
+                      , string "DEADLINE"  *> pure DEADLINE
+                      , string "CLOSED"    *> pure CLOSED
                       ]
 
 -- | Parse a clock line.
@@ -69,8 +69,7 @@ parseClock :: Attoparsec.Parser Text (Maybe Timestamp, Maybe Duration)
 parseClock = (,) <$> (skipSpace *> string "CLOCK: " *> ts) <*> dur
   where
     ts  = option Nothing (Just <$> parseTimestamp)
-    dur = option Nothing (Just <$> (string " => "
-                                    *> skipSpace *> parseHM))
+    dur = option Nothing (Just <$> (string " => " *> skipSpace *> parseHM))
 
 -- | Parse a timestamp.
 --
@@ -176,7 +175,6 @@ transformBracketedDateTime BracketedDateTime{..} =
       )
     dateStamp = (defdt, Nothing, activeState)
 
-
 -- | Parse a day name in the same way as org-mode does.
 --
 -- The character set (@]+0123456789>\r\n -@) is based on a part of a
@@ -196,13 +194,13 @@ parseDay = Text.pack <$> some (Attoparsec.satisfyElem isDayChar)
 parseTime' :: Attoparsec.Parser Text TimePart
 parseTime' = stampRng <|> stampAbs
   where
-    -- Applicative-do cleans this up real nice
+    stampRng :: Maybe TimeStampRange
     stampRng = do
       beg <- parseHM <* char '-'
       end <- parseHM
       pure $ TimeStampRange (beg,end)
 
-    stampAbs = AbsoluteTime   <$> parseHM
+    stampAbs = AbsoluteTime <$> parseHM
 
 -- | Parse the YYYY-MM-DD part of a time part.
 parseDate :: Attoparsec.Parser Text YearMonthDay

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -37,33 +37,11 @@ import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import           Data.Thyme.Format          (buildTime, timeParser)
 import           Data.Thyme.LocalTime       (Hours, Minutes)
-import           Prelude                    hiding (concat, null, takeWhile,
-                                             unwords, words)
+import           Prelude                    hiding (concat, null, repeat,
+                                             takeWhile, unwords, words)
 import           System.Locale              (defaultTimeLocale)
 
 import           Data.OrgMode.Types
-
-type Weekday = Text
-type AbsTime = (Hours, Minutes)
-
--- | A data type for parsed org-mode bracketed datetime stamps, e.g:
---
--- > [2015-03-27 Fri 10:20 +4h]
-data BracketedDateTime = BracketedDateTime
-  { datePart    :: YearMonthDay
-  , dayNamePart :: Maybe Weekday
-  , timePart    :: Maybe TimePart
-  , repeat      :: Maybe Repeater
-  , delayPart   :: Maybe Delay
-  , activeState :: ActiveState
-  } deriving (Show, Eq)
-
--- | A sum type representing an absolute time part of a bracketed
--- org-mode datetime stamp or a time range between two absolute
--- timestamps.
-data TimePart = AbsoluteTime   AbsTime
-              | TimeStampRange (AbsTime, AbsTime)
-  deriving (Eq, Ord, Show)
 
 -- | Parse a planning line.
 --
@@ -185,7 +163,7 @@ transformBracketedDateTime :: BracketedDateTime
 transformBracketedDateTime BracketedDateTime{..} =
   maybe dateStamp timeStamp timePart
   where
-    defdt = DateTime (YMD' datePart) dayNamePart Nothing repeat delayPart
+    defdt = DateTime datePart dayNamePart Nothing repeat delayPart
     timeStamp (AbsoluteTime   (hs,ms)) =
       ( defdt { hourMinute = Just (hs,ms) }
       , Nothing

--- a/src/Data/OrgMode/Parse/Attoparsec/Time.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Time.hs
@@ -41,7 +41,7 @@ import           Prelude                    hiding (concat, null, takeWhile,
                                              unwords, words)
 import           System.Locale              (defaultTimeLocale)
 
-import           Data.OrgMode.Parse.Types
+import           Data.OrgMode.Types
 
 type Weekday = Text
 type AbsTime = (Hours, Minutes)

--- a/src/Data/OrgMode/Types.hs
+++ b/src/Data/OrgMode/Types.hs
@@ -1,5 +1,5 @@
 {-|
-Module      :  Data.OrgMode.Parse.Types
+Module      :  Data.OrgMode.Types
 Copyright   :  © 2014 Parnell Springmeyer
 License     :  All Rights Reserved
 Maintainer  :  Parnell Springmeyer <parnell@digitalmentat.com>
@@ -12,7 +12,7 @@ Types and utility functions.
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 
-module Data.OrgMode.Parse.Types
+module Data.OrgMode.Types
 ( ActiveState     (..)
 , Document        (..)
 , DateTime        (..)

--- a/src/Data/OrgMode/Types.hs
+++ b/src/Data/OrgMode/Types.hs
@@ -77,18 +77,20 @@ instance Aeson.ToJSON Depth where
 instance Aeson.FromJSON Depth where
 
 -- | Section of text directly following a headline.
-data Section = Section {
-      sectionPlannings  :: Plannings  -- ^ A map of planning timestamps
-    , sectionClocks     :: [Clock]    -- ^ A list of clocks
-    , sectionProperties :: Properties -- ^ A map of properties from a property drawer
-    , sectionParagraph  :: Text       -- ^ Arbitrary text
+data Section = Section
+  { sectionPlannings  :: Plannings  -- ^ A map of planning timestamps
+  , sectionClocks     :: [Clock]    -- ^ A list of clocks
+  , sectionProperties :: Properties -- ^ A map of properties from a property drawer
+  , sectionParagraph  :: Text       -- ^ Arbitrary text
   } deriving (Show, Eq, Generic)
 
 type Properties = HashMap Text Text
 type Clock      = (Maybe Timestamp, Maybe Duration)
 
 -- | Sum type indicating the active state of a timestamp.
-data ActiveState = Active | Inactive
+data ActiveState
+  = Active
+  | Inactive
   deriving (Show, Eq, Read, Generic)
 
 instance Aeson.ToJSON ActiveState where
@@ -143,8 +145,9 @@ data BracketedDateTime = BracketedDateTime
 -- | A sum type representing an absolute time part of a bracketed
 -- org-mode datetime stamp or a time range between two absolute
 -- timestamps.
-data TimePart = AbsoluteTime   AbsTime
-              | TimeStampRange (AbsTime, AbsTime)
+data TimePart
+  = AbsoluteTime   AbsTime
+  | TimeStampRange (AbsTime, AbsTime)
   deriving (Eq, Ord, Show)
 
 -- | A data type for parsed org-mode datetime stamps.
@@ -164,16 +167,19 @@ instance Aeson.FromJSON DateTime where
 
 -- | A sum type representing the repeater type of a repeater interval
 -- in a org-mode timestamp.
-data RepeaterType = RepeatCumulate | RepeatCatchUp | RepeatRestart
-                  deriving (Show, Eq, Generic)
+data RepeaterType
+  = RepeatCumulate
+  | RepeatCatchUp
+  | RepeatRestart
+  deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON RepeaterType
 instance Aeson.FromJSON RepeaterType
 
 -- | A data type representing a repeater interval in a org-mode
 -- timestamp.
-data Repeater = Repeater {
-    repeaterType  :: RepeaterType -- ^ Type of repeater
+data Repeater = Repeater
+  { repeaterType  :: RepeaterType -- ^ Type of repeater
   , repeaterValue :: Int          -- ^ Repeat value
   , repeaterUnit  :: TimeUnit     -- ^ Repeat time unit
   } deriving (Show, Eq, Generic)
@@ -182,15 +188,17 @@ instance Aeson.ToJSON Repeater where
 instance Aeson.FromJSON Repeater where
 
 -- | A sum type representing the delay type of a delay value.
-data DelayType = DelayAll | DelayFirst
-               deriving (Show, Eq, Generic)
+data DelayType
+  = DelayAll
+  | DelayFirst
+  deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON   DelayType where
 instance Aeson.FromJSON DelayType where
 
 -- | A data type representing a delay value.
-data Delay = Delay {
-    delayType  :: DelayType -- ^ Type of delay
+data Delay = Delay
+  { delayType  :: DelayType -- ^ Type of delay
   , delayValue :: Int       -- ^ Delay value
   , delayUnit  :: TimeUnit  -- ^ Delay time unit
   } deriving (Show, Eq, Generic)
@@ -199,12 +207,13 @@ instance Aeson.ToJSON Delay where
 instance Aeson.FromJSON Delay where
 
 -- | A sum type representing the time units of a delay.
-data TimeUnit = UnitYear
-              | UnitWeek
-              | UnitMonth
-              | UnitDay
-              | UnitHour
-              deriving (Show, Eq, Generic)
+data TimeUnit
+  = UnitYear
+  | UnitWeek
+  | UnitMonth
+  | UnitDay
+  | UnitHour
+  deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON TimeUnit where
 instance Aeson.FromJSON TimeUnit where

--- a/src/Data/OrgMode/Types.hs
+++ b/src/Data/OrgMode/Types.hs
@@ -5,7 +5,7 @@ License     :  All Rights Reserved
 Maintainer  :  Parnell Springmeyer <parnell@digitalmentat.com>
 Stability   :  experimental
 
-Types and utility functions.
+Types for the AST of an org-mode document.
 -}
 
 {-# LANGUAGE DeriveGeneric              #-}
@@ -13,28 +13,29 @@ Types and utility functions.
 {-# LANGUAGE OverloadedStrings          #-}
 
 module Data.OrgMode.Types
-( ActiveState     (..)
-, Document        (..)
-, DateTime        (..)
-, Delay           (..)
-, DelayType       (..)
+( ActiveState       (..)
+, BracketedDateTime (..)
+, Document          (..)
+, DateTime          (..)
+, Delay             (..)
+, DelayType         (..)
 , Duration
-, Headline        (..)
-, Depth           (..)
-, PlanningKeyword (..)
-, Plannings       (..)
-, Priority        (..)
+, Headline          (..)
+, Depth             (..)
+, PlanningKeyword   (..)
+, Plannings         (..)
+, Priority          (..)
 , Properties
-, Repeater        (..)
-, RepeaterType    (..)
-, Section         (..)
-, StateKeyword    (..)
-, Stats           (..)
+, Repeater          (..)
+, RepeaterType      (..)
+, Section           (..)
+, StateKeyword      (..)
+, Stats             (..)
 , Tag
-, TimeUnit        (..)
-, Timestamp       (..)
-, YearMonthDay    (..)
-, YearMonthDay'   (..)
+, TimeUnit          (..)
+, Timestamp         (..)
+, TimePart          (..)
+, YearMonthDay      (..)
 ) where
 
 import           Control.Monad        (mzero)
@@ -44,16 +45,47 @@ import           Data.Hashable        (Hashable (..))
 import           Data.HashMap.Strict  (HashMap, fromList, keys, toList)
 import           Data.Text            (Text, pack)
 import           Data.Thyme.Calendar  (YearMonthDay (..))
-import           Data.Thyme.LocalTime (Hour, Minute)
+import           Data.Thyme.LocalTime (Hour, Hours, Minute, Minutes)
 import           GHC.Generics
 
-data Document = Document {
-    documentText      :: Text      -- ^ Text occurring before any Org headlines
+-- | Org-mode document.
+data Document = Document
+  { documentText      :: Text       -- ^ Text occurring before any Org headlines
   , documentHeadlines :: [Headline] -- ^ Toplevel Org headlines
   } deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON Document where
 instance Aeson.FromJSON Document where
+
+-- | Headline within an org-mode document.
+data Headline = Headline
+  { depth        :: Depth              -- ^ Org headline nesting depth (1 is at the top), e.g: * or ** or ***
+  , stateKeyword :: Maybe StateKeyword -- ^ State of the headline, e.g: TODO, DONE
+  , priority     :: Maybe Priority     -- ^ Headline priority, e.g: [#A]
+  , title        :: Text               -- ^ Primary text of the headline
+  , stats        :: Maybe Stats        -- ^ Fraction of subtasks completed, e.g: [33%] or [1/2]
+  , tags         :: [Tag]              -- ^ Tags on the headline
+  , section      :: Section            -- ^ The body underneath a headline
+  , subHeadlines :: [Headline]         -- ^ A list of sub-headlines
+  } deriving (Show, Eq, Generic)
+
+-- | Headline nesting depth.
+newtype Depth = Depth Int
+  deriving (Eq, Show, Num, Generic)
+
+instance Aeson.ToJSON Depth where
+instance Aeson.FromJSON Depth where
+
+-- | Section of text directly following a headline.
+data Section = Section {
+      sectionPlannings  :: Plannings  -- ^ A map of planning timestamps
+    , sectionClocks     :: [Clock]    -- ^ A list of clocks
+    , sectionProperties :: Properties -- ^ A map of properties from a property drawer
+    , sectionParagraph  :: Text       -- ^ Arbitrary text
+  } deriving (Show, Eq, Generic)
+
+type Properties = HashMap Text Text
+type Clock      = (Maybe Timestamp, Maybe Duration)
 
 -- | Sum type indicating the active state of a timestamp.
 data ActiveState = Active | Inactive
@@ -62,60 +94,65 @@ data ActiveState = Active | Inactive
 instance Aeson.ToJSON ActiveState where
 instance Aeson.FromJSON ActiveState where
 
-newtype Depth = Depth Int
-  deriving (Eq, Show, Num, Generic)
-
-data Headline = Headline
-    { depth        :: Depth              -- ^ Org headline nesting depth (1 is at the top), e.g: * or ** or ***
-    , stateKeyword :: Maybe StateKeyword -- ^ State of the headline, e.g: TODO, DONE
-    , priority     :: Maybe Priority     -- ^ Headline priority, e.g: [#A]
-    , title        :: Text               -- ^ Primary text of the headline
-    , stats        :: Maybe Stats        -- ^ Fraction of subtasks completed, e.g: [33%] or [1/2]
-    , tags         :: [Tag]              -- ^ Tags on the headline
-    , section      :: Section            -- ^ The body underneath a headline
-    , subHeadlines :: [Headline]          -- ^ A list of sub-headlines
-    } deriving (Show, Eq, Generic)
-
-type Properties = HashMap Text Text
-type Clock      = (Maybe Timestamp, Maybe Duration)
-
-data Section = Section {
-      sectionPlannings  :: Plannings
-    , sectionClocks     :: [Clock]
-    , sectionProperties :: Properties
-    , sectionParagraph  :: Text
-  } deriving (Show, Eq, Generic)
-
-
-data Timestamp = Timestamp {
-    tsTime    :: DateTime
-  , tsActive  :: ActiveState
-  , tsEndTime :: Maybe DateTime
+-- | A generic data type for parsed org-mode time stamps, e.g:
+--
+-- > <2015-03-27 Fri 10:20>
+-- > [2015-03-27 Fri 10:20 +4h]
+-- > <2015-03-27 Fri 10:20>--<2015-03-28 Sat 10:20>
+data Timestamp = Timestamp
+  { tsTime    :: DateTime       -- ^ A datetime stamp
+  , tsActive  :: ActiveState    -- ^ Active or inactive?
+  , tsEndTime :: Maybe DateTime -- ^ A end-of-range datetime stamp
   } deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON Timestamp where
 instance Aeson.FromJSON Timestamp where
 
+instance Aeson.ToJSON YearMonthDay where
+  toJSON (YearMonthDay y m d) =
+    Aeson.object
+      [ "ymdYear"  .= y
+      , "ymdMonth" .= m
+      , "ymdDay"   .= d
+      ]
 
-newtype YearMonthDay' = YMD' YearMonthDay
-                        deriving (Show, Eq, Generic)
-
-instance Aeson.ToJSON YearMonthDay' where
-  toJSON (YMD' (YearMonthDay y m d)) =
-    Aeson.object ["ymdYear"  .= y
-             ,"ymdMonth" .= m
-             ,"ymdDay"   .= d]
-
-instance Aeson.FromJSON YearMonthDay' where
+instance Aeson.FromJSON YearMonthDay where
   parseJSON (Aeson.Object v) = do
     y <- v .: "ymdYear"
     m <- v .: "ymdMonth"
     d <- v .: "ymdDay"
-    pure (YMD' (YearMonthDay y m d))
+    pure (YearMonthDay y m d)
   parseJSON _ = mzero
 
+
+type Weekday = Text
+type AbsTime = (Hours, Minutes)
+
+-- | A data type for parsed org-mode bracketed datetime stamps, e.g:
+--
+-- > [2015-03-27 Fri 10:20 +4h]
+data BracketedDateTime = BracketedDateTime
+  { datePart    :: YearMonthDay
+  , dayNamePart :: Maybe Weekday
+  , timePart    :: Maybe TimePart
+  , repeat      :: Maybe Repeater
+  , delayPart   :: Maybe Delay
+  , activeState :: ActiveState
+  } deriving (Show, Eq)
+
+-- | A sum type representing an absolute time part of a bracketed
+-- org-mode datetime stamp or a time range between two absolute
+-- timestamps.
+data TimePart = AbsoluteTime   AbsTime
+              | TimeStampRange (AbsTime, AbsTime)
+  deriving (Eq, Ord, Show)
+
+-- | A data type for parsed org-mode datetime stamps.
+--
+-- TODO: why do we have this data type and BracketedDateTime? They
+-- look almost exactly the same...
 data DateTime = DateTime {
-    yearMonthDay :: YearMonthDay'
+    yearMonthDay :: YearMonthDay
   , dayName      :: Maybe Text
   , hourMinute   :: Maybe (Hour,Minute)
   , repeater     :: Maybe Repeater
@@ -125,36 +162,43 @@ data DateTime = DateTime {
 instance Aeson.ToJSON DateTime where
 instance Aeson.FromJSON DateTime where
 
+-- | A sum type representing the repeater type of a repeater interval
+-- in a org-mode timestamp.
 data RepeaterType = RepeatCumulate | RepeatCatchUp | RepeatRestart
                   deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON RepeaterType
 instance Aeson.FromJSON RepeaterType
 
+-- | A data type representing a repeater interval in a org-mode
+-- timestamp.
 data Repeater = Repeater {
-    repeaterType  :: RepeaterType
-  , repeaterValue :: Int
-  , repeaterUnit  :: TimeUnit
+    repeaterType  :: RepeaterType -- ^ Type of repeater
+  , repeaterValue :: Int          -- ^ Repeat value
+  , repeaterUnit  :: TimeUnit     -- ^ Repeat time unit
   } deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON Repeater where
 instance Aeson.FromJSON Repeater where
 
+-- | A sum type representing the delay type of a delay value.
 data DelayType = DelayAll | DelayFirst
                deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON   DelayType where
 instance Aeson.FromJSON DelayType where
 
+-- | A data type representing a delay value.
 data Delay = Delay {
-    delayType  :: DelayType
-  , delayValue :: Int
-  , delayUnit  :: TimeUnit
+    delayType  :: DelayType -- ^ Type of delay
+  , delayValue :: Int       -- ^ Delay value
+  , delayUnit  :: TimeUnit  -- ^ Delay time unit
   } deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON Delay where
 instance Aeson.FromJSON Delay where
 
+-- | A sum type representing the time units of a delay.
 data TimeUnit = UnitYear
               | UnitWeek
               | UnitMonth
@@ -165,29 +209,22 @@ data TimeUnit = UnitYear
 instance Aeson.ToJSON TimeUnit where
 instance Aeson.FromJSON TimeUnit where
 
----------------------------------------------------------------------------
---instance Aeson.ToJSON Document where
---instance Aeson.FromJSON Document where
-
-instance Aeson.ToJSON Depth where
-instance Aeson.FromJSON Depth where
-
+-- | A type representing a headline state keyword, e.g: @TODO@,
+-- @DONE@, @WAITING@, etc.
 newtype StateKeyword = StateKeyword {unStateKeyword :: Text}
   deriving (Show, Eq, Generic)
 
 instance Aeson.ToJSON StateKeyword where
 instance Aeson.FromJSON StateKeyword where
 
-
+-- | A sum type representing the planning keywords.
 data PlanningKeyword = SCHEDULED | DEADLINE | CLOSED
   deriving (Show, Eq, Enum, Ord, Generic)
 
 instance Aeson.ToJSON PlanningKeyword where
 instance Aeson.FromJSON PlanningKeyword where
 
---instance (Aeson.ToJSON k, Aeson.ToJSON v) => Aeson.ToJSON (HashMap k v) where
---  toJSON hm = Aeson.object hm
-
+-- | A type representing a map of planning timestamps.
 newtype Plannings = Plns (HashMap PlanningKeyword Timestamp)
                   deriving (Show, Eq, Generic)
 
@@ -206,6 +243,8 @@ instance Aeson.FromJSON Section where
 instance Aeson.ToJSON Headline where
 instance Aeson.FromJSON Headline where
 
+-- | A sum type representing the three default priorities: @A@, @B@,
+-- and @C@.
 data Priority = A | B | C
   deriving (Show, Read, Eq, Ord, Generic)
 
@@ -213,6 +252,10 @@ instance Aeson.ToJSON Priority where
 instance Aeson.FromJSON Priority where
 type Tag = Text
 
+-- | A data type representing a stats value in a headline, e.g @[2/3]@
+-- in this headline:
+--
+-- > * TODO [2/3] work on orgmode-parse
 data Stats = StatsPct Int
            | StatsOf  Int Int
            deriving (Show, Eq, Generic)
@@ -224,11 +267,3 @@ type Duration = (Hour,Minute)
 
 instance Hashable PlanningKeyword where
   hashWithSalt salt k = hashWithSalt salt (fromEnum k)
-
--- -- This might be the form to use if we were supporting <diary> timestamps
--- data Timestamp = Dairy Text
---                | Time  TimestampTime
---               deriving (Show, Eq, Generic)
-
-
-

--- a/test/Document.hs
+++ b/test/Document.hs
@@ -12,7 +12,7 @@ import           Test.Tasty.HUnit
 
 import           Data.OrgMode.Parse.Attoparsec.Document
 import           Data.OrgMode.Parse.Attoparsec.Time
-import           Data.OrgMode.Parse.Types
+import           Data.OrgMode.Types
 import           Util
 
 parserSmallDocumentTests :: TestTree

--- a/test/Timestamps.hs
+++ b/test/Timestamps.hs
@@ -31,7 +31,7 @@ parserPlanningTests = testGroup "Attoparsec Planning"
       ("SCHEDULED: <2004-02-29 Sun 10:20 +1w -2d>"
        ,(fromList [(SCHEDULED, Timestamp
                                     (DateTime
-                                     (YMD' (YearMonthDay 2004 2 29))
+                                     (YearMonthDay 2004 2 29)
                                      (Just "Sun")
                                      (Just (10,20))
                                      (Just (Repeater RepeatCumulate 1 UnitWeek))
@@ -58,7 +58,7 @@ parserWeekdayTests = testGroup "Attoparsec Weekday"
       where
         str = "<2004-02-29 " <> w <> " 10:20>"
         res = Timestamp (DateTime
-                         (YMD' (YearMonthDay 2004 2 29))
+                         (YearMonthDay 2004 2 29)
                          (Just w)
                          (Just (10,20))
                          Nothing

--- a/test/Timestamps.hs
+++ b/test/Timestamps.hs
@@ -3,18 +3,17 @@
 
 module Timestamps where
 
-import           Control.Applicative      ((<*))
-import           Control.Monad            (guard)
-import           Data.Attoparsec.Text     (endOfLine)
+import           Control.Applicative  ((<*))
+import           Data.Attoparsec.Text (endOfLine)
 import           Data.HashMap.Strict
-import           Data.Monoid              ((<>))
+import           Data.Monoid          ((<>))
 import           Data.OrgMode.Parse
-import qualified Data.Text                as T
+import qualified Data.Text            as T
 import           Test.Tasty
 import           Test.Tasty.HUnit
-import           Weekdays                 (weekdays)
+import           Weekdays             (weekdays)
 
-import           Data.OrgMode.Parse.Types
+import           Data.OrgMode.Types
 import           Util
 
 parserPlanningTests :: TestTree
@@ -28,16 +27,16 @@ parserPlanningTests = testGroup "Attoparsec Planning"
     testPlanning  t   = testParser parsePlannings t
     testPlanningS t r = expectParse parsePlannings t (Right r)
 
-(sExampleStrA, sExampleResA) =
-  ("SCHEDULED: <2004-02-29 Sun 10:20 +1w -2d>"
-   ,(fromList [(SCHEDULED, Timestamp
-                                (DateTime
-                                 (YMD' (YearMonthDay 2004 2 29))
-                                 (Just "Sun")
-                                 (Just (10,20))
-                                 (Just (Repeater RepeatCumulate 1 UnitWeek))
-                                 (Just (Delay DelayAll 2 UnitDay))
-                                ) Active Nothing)]))
+    (sExampleStrA, sExampleResA) =
+      ("SCHEDULED: <2004-02-29 Sun 10:20 +1w -2d>"
+       ,(fromList [(SCHEDULED, Timestamp
+                                    (DateTime
+                                     (YMD' (YearMonthDay 2004 2 29))
+                                     (Just "Sun")
+                                     (Just (10,20))
+                                     (Just (Repeater RepeatCumulate 1 UnitWeek))
+                                     (Just (Delay DelayAll 2 UnitDay))
+                                    ) Active Nothing)]))
 
 parserTimestampTests :: TestTree
 parserTimestampTests = testGroup "Attoparsec Timestamp"
@@ -53,6 +52,8 @@ parserWeekdayTests = testGroup "Attoparsec Weekday"
   [testCase ("Parse Weekday in " ++ loc) $ mkTest w
   | (loc,ws) <- weekdays, w <- ws, isOrgParsable w]
   where
+    dayChars = "]+0123456789>\r\n -" :: String
+    isOrgParsable w = T.find (\c -> c `elem` dayChars) w == Nothing
     mkTest w = expectParse parseTimestamp str (Right res)
       where
         str = "<2004-02-29 " <> w <> " 10:20>"
@@ -62,6 +63,3 @@ parserWeekdayTests = testGroup "Attoparsec Weekday"
                          (Just (10,20))
                          Nothing
                          Nothing) Active Nothing
-
-    dayChars = "]+0123456789>\r\n -" :: String
-    isOrgParsable w = T.find (\c -> c `elem` dayChars) w == Nothing


### PR DESCRIPTION
Relocating the Types module to a more general location and changing import qualification paths to match. This fixes #15.

Additionally, there are minor fixes and improvements to the `README.md`.