### PR TITLE
Fixes #13

### DIFF
--- a/src/Data/OrgMode/Parse/Attoparsec/Section.hs
+++ b/src/Data/OrgMode/Parse/Attoparsec/Section.hs
@@ -35,7 +35,8 @@ import           Data.OrgMode.Types
 parseSection :: Attoparsec.Parser Text Section
 parseSection =
   Section
-   <$> (Plns <$> parsePlannings)
+   <$> option Nothing (Just <$> (skipSpace *> parseTimestamp <* skipSpace))
+   <*> (Plns <$> parsePlannings)
    <*> many' parseClock
    <*> option mempty parseProperties
    <*> option mempty parseLogbook

--- a/src/Data/OrgMode/Types.hs
+++ b/src/Data/OrgMode/Types.hs
@@ -68,6 +68,7 @@ data Headline = Headline
   , stateKeyword :: Maybe StateKeyword -- ^ State of the headline, e.g: TODO, DONE
   , priority     :: Maybe Priority     -- ^ Headline priority, e.g: [#A]
   , title        :: Text               -- ^ Primary text of the headline
+  , timestamp    :: Maybe Timestamp    -- ^ A timestamp that may be embedded in the headline
   , stats        :: Maybe Stats        -- ^ Fraction of subtasks completed, e.g: [33%] or [1/2]
   , tags         :: [Tag]              -- ^ Tags on the headline
   , section      :: Section            -- ^ The body underneath a headline
@@ -83,12 +84,13 @@ instance Aeson.FromJSON Depth
 
 -- | Section of text directly following a headline.
 data Section = Section
-  { sectionPlannings  :: Plannings  -- ^ A map of planning timestamps
-  , sectionClocks     :: [Clock]    -- ^ A list of clocks
-  , sectionProperties :: Properties -- ^ A map of properties from the :PROPERTY: drawer
-  , sectionLogbook    :: Logbook    -- ^ A list of clocks from the :LOGBOOK: drawer
-  , sectionDrawers    :: [Drawer]   -- ^ A list of parsed user-defined drawers
-  , sectionParagraph  :: Text       -- ^ Arbitrary text
+  { sectionTimestamp  :: Maybe Timestamp -- ^ A headline's section timestamp
+  , sectionPlannings  :: Plannings       -- ^ A map of planning timestamps
+  , sectionClocks     :: [Clock]         -- ^ A list of clocks
+  , sectionProperties :: Properties      -- ^ A map of properties from the :PROPERTY: drawer
+  , sectionLogbook    :: Logbook         -- ^ A list of clocks from the :LOGBOOK: drawer
+  , sectionDrawers    :: [Drawer]        -- ^ A list of parsed user-defined drawers
+  , sectionParagraph  :: Text            -- ^ Arbitrary text
   } deriving (Show, Eq, Generic)
 
 newtype Properties = Properties { unProperties :: HashMap Text Text }

--- a/test/Document.hs
+++ b/test/Document.hs
@@ -76,15 +76,18 @@ samplePParse = Document
     Right con = parseOnly parsePlannings "SCHEDULED: <2015-06-12 Fri>"
 
 emptyHeadline :: Headline
-emptyHeadline = Headline {depth = 1
-                       ,stateKeyword     = Nothing
-                       ,priority    = Nothing
-                       ,title       = ""
-                       ,stats       = Nothing
-                       ,tags        = []
-                       ,section     = emptySection
-                       ,subHeadlines = []
-                       }
+emptyHeadline =
+  Headline
+   { depth        = 1
+   , stateKeyword = Nothing
+   , priority     = Nothing
+   , title        = ""
+   , stats        = Nothing
+   , timestamp    = Nothing
+   , tags         = []
+   , section      = emptySection
+   , subHeadlines = []
+   }
 
 sampleParagraph :: Text
 sampleParagraph = "This is some sample text in a paragraph which may contain * , : , and other special characters.\n\n"
@@ -93,4 +96,4 @@ spaces :: Int -> Text
 spaces = flip Text.replicate " "
 
 emptySection :: Section
-emptySection = Section (Plns mempty) mempty mempty mempty mempty mempty
+emptySection = Section Nothing (Plns mempty) mempty mempty mempty mempty mempty

--- a/test/Headline.hs
+++ b/test/Headline.hs
@@ -20,6 +20,7 @@ parserHeadlineTests = testGroup "Attoparsec Headline"
     , (testCase "Parse Headline w/ Keywords"         $ testHeadline "* An important heading :WITH:KEYWORDS:\n")
     , (testCase "Parse Headline Full"                $ testHeadline "* DONE [#B] A heading : with [[http://somelink.com][a link]] :WITH:KEYWORDS:\n")
     , (testCase "Parse Headline All But Title"       $ testHeadline "* DONE [#A] :WITH:KEYWORDS:\n")
+    , (testCase "Parse Headline w/ Timestamp"        $ testHeadline "* TODO [#A] Pickup groceris on <2017-08-24 22:00>\n")
     ]
   where
     testHeadline = testParser (headlineBelowDepth ["TODO","CANCELED","DONE"] 0)

--- a/test/test-document.org
+++ b/test/test-document.org
@@ -5,9 +5,10 @@
 
   This should be parsed by the document parser combinator.
 
-  Another WTF
+  Another line
 
 ** A sub-heading
+   <2017-08-22 13:22-20:00>
    :LOGBOOK:
    CLOCK: [2015-10-05 Mon 17:13]--[2015-10-05 Mon 17:14] =>  0:01
    :END:
@@ -23,5 +24,6 @@ boolkjsdf
 
 asdklfjskldjf
    :END:
+
 
    extra section *text*


### PR DESCRIPTION
This change adds a field to the headline data type and a field to the section data type for timestamps that can be parsed in the headline and in the beginning of a section.