### PR TITLE
Fix headline timestamp parser

### DIFF
--- a/test/test-document.org
+++ b/test/test-document.org
@@ -1,4 +1,4 @@
-* TODO Test the parsing of an entire document from file                                :TESTING:DOC:
+* TODO  [#A] <2017-08-22 13:22-20:00> Test the parsing of an entire document from file :TESTING:DOC:
   :PROPERTIES:
   :DATE: [2015-08-02 Sun]
   :END:


### PR DESCRIPTION
This fixes a bug I introduced in #29. The org-mode say timestamps can be anywhere in a headline or headline section body. This kind of grammar is difficult for me to support at the moment with the current code, so until I have more time to write a parser that keeps track of what it consumes and backtracks, not just on failure but also on success (using `match`), this feature will impose a restriction: the timestamp must come before the title text (i.e: in the preamble metadata with the state and priority).