### PR TITLE
Add position annotation in Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ parsing implementation and not:
     - [X] Numbered lists
     - [ ] Checkbox modified lists
   - [ ] Blocks (src / quote / example blocks)
+- [ ] Position Annotated AST
 
 ## Building
 There are a few ways to build this library if you're developing a patch:


### PR DESCRIPTION
Hi, I am thinking about `{line: Int, column: Int, position: Int}` in the parser.  Because for some tools manipulate the org file (for example, writing an orgmode language server that can add schedule, drawer and other things near the current cursor), perhaps it is good to have position annotated. 

It is somehow doable by (https://github.com/bos/attoparsec/issues/101)
```
getPos :: Parser Int
getPos = AT.Parser $ \t pos more _ succ' -> succ' t pos more (AT.fromPos pos)
```
But I am still thinking about what is the best interface to inject this code.   However, I think it is not bad to add this in the proposal.