### PR TITLE
Make `haddock2hackage` usable on NixOS

### DIFF
--- a/haddock2hackage
+++ b/haddock2hackage
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
  
 # Options / Usage
 # put this script in the same directory as your *.cabal file


### PR DESCRIPTION
NixOS requires the use of `/usr/bin/env` rather than a hardcoded `/bin/bash`. The two are still identical on most Linux systems.